### PR TITLE
fix customer event detail

### DIFF
--- a/src/render/component.js
+++ b/src/render/component.js
@@ -94,7 +94,7 @@ class Component {
       setTimeout(() => {
         dom.dispatchEvent(customEvent)
 
-        exparser.Event.dispatchEvent(customEvent.target, exparser.Event.create(eventName, {}, {
+        exparser.Event.dispatchEvent(customEvent.target, exparser.Event.create(eventName, options.detail || {}, {
           originalEvent: customEvent,
           bubbles: true,
           capturePhase: true,

--- a/test/component.test.js
+++ b/test/component.test.js
@@ -205,7 +205,8 @@ test('dispatchEvent', async () => {
       onBlur() {
         blurCount++;
       },
-      onTap2() {
+      onTap2(e) {
+        expect(e.detail.userInfo.nickName).toBe('hello');
         this.setData({
           index: ++this.data.index,
           'styleObject.style': 'color: red;',
@@ -333,7 +334,7 @@ test('dispatchEvent', async () => {
   expect(longPressCount).toBe(1);
 
   let node2 = comp.querySelector('#compa');
-  node2.dispatchEvent('tap');
+  node2.dispatchEvent('tap', { detail: { userInfo: { nickName: 'hello' } } });
   await _.sleep(10);
   expect(comp.dom.innerHTML).toBe('<wx-view class="a" style="color: red;"><div>1</div></wx-view><wx-view><div>if</div></wx-view><compa><wx-view><div>0-2</div></wx-view><wx-view><div>1-3</div></wx-view><wx-view><div>2-4</div></wx-view><span>1</span></compa>');
 
@@ -345,7 +346,7 @@ test('dispatchEvent', async () => {
   // 其他自定义事件
   let event = null;
   comp.dom.addEventListener('test', evt => {
-    event = evt; 
+    event = evt;
   });
   comp.dispatchEvent('test');
   await _.sleep(10);


### PR DESCRIPTION
修复 组件 dispatchEvent方法中自定义事件传入detail，但是组件函数接收不到detail问题。
原因：

跟踪miniprogram-exparser源码发现`Event.create`的第二个参数为`detail`
文件版本`0.0.6`，Webstorm格式化之后：代码行数`168`
```js
i.create = function(e, t, r) {
      r = r || {};
      var n = r.originalEvent, o = r.extraFields || {}, a = Date.now() - l, s = new i;
      s.currentTarget = null, s.type = e, s.timeStamp = a, s.mark = null, s.detail = t, s.bubbles = !!r.bubbles, s.composed = !!r.composed, s.__originalEvent = n, s.__hasCapture = !!r.capturePhase, s.__stopped = !1, s.__dispatched = !1;
      for (var u in o) s[u] = o[u];
      return s;
    }
```
可以看到`s.detail` = `t` 的赋值。但是component.js在dispatchEvent自定义事件时第二个参数写死了`{}`，导致组件内部无法获取detail参数