### PR TITLE
Add "callDefinitionFilter" to behavior

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ module.exports = {
     }
 
     _.adjustExparserDefinition(definition)
+    definition.definitionFilter = exparser.Behavior.callDefinitionFilter(definition)
     exparser.registerBehavior(definition)
 
     return definition.is


### PR DESCRIPTION
I guess it should invoke the `callDefinitionFilter` here according to
![image](https://user-images.githubusercontent.com/5362563/101981648-6bc2cc00-3ca9-11eb-896d-57118556d198.png)
which is a code snippet with similar function from the devtool.